### PR TITLE
Require utf8-string >= 0.3.1

### DIFF
--- a/string-conversions.cabal
+++ b/string-conversions.cabal
@@ -36,7 +36,7 @@ library
       base ==4.*
     , bytestring >=0.9
     , text >=0.11
-    , utf8-string >=0.3
+    , utf8-string >=0.3.1
   default-language: Haskell2010
 
 test-suite spec
@@ -58,5 +58,5 @@ test-suite spec
     , hspec
     , quickcheck-instances
     , text >=0.11
-    , utf8-string >=0.3
+    , utf8-string >=0.3.1
   default-language: Haskell2010


### PR DESCRIPTION
`utf8-string-0.3` does not provide `Data.ByteString.Lazy.UTF8` yet.

As a Hackage trustee I made appropriate revisions to prohibit unbuildable configurations.